### PR TITLE
Simplify recording of results

### DIFF
--- a/compression_results.json
+++ b/compression_results.json
@@ -1,38 +1,22 @@
 {
     "zlib": {
         "compression_ratio": 27.836415022034874,
-        "total_compress_time": [
-            7.344542980194092
-        ],
-        "total_decompress_time": [
-            11.987490892410278
-        ]
+        "total_compress_time": 7.344542980194092,
+        "total_decompress_time": 11.987490892410278
     },
     "lz4": {
         "compression_ratio": 18.226421603989586,
-        "total_compress_time": [
-            0.13016223907470703
-        ],
-        "total_decompress_time": [
-            0.45842909812927246
-        ]
+        "total_compress_time": 0.13016223907470703,
+        "total_decompress_time": 0.45842909812927246
     },
     "brotli": {
         "compression_ratio": 64.77683647307992,
-        "total_compress_time": [
-            204.17940878868103
-        ],
-        "total_decompress_time": [
-            0.991732120513916
-        ]
+        "total_compress_time": 204.17940878868103,
+        "total_decompress_time": 0.991732120513916
     },
     "zstandard": {
         "compression_ratio": 43.421729059254275,
-        "total_compress_time": [
-            0.14809560775756836
-        ],
-        "total_decompress_time": [
-            0.45727968215942383
-        ]
+        "total_compress_time": 0.14809560775756836,
+        "total_decompress_time": 0.45727968215942383
     }
 }

--- a/py_compress_compare.py
+++ b/py_compress_compare.py
@@ -4,7 +4,6 @@ import zlib
 import lz4.frame
 import brotli
 import zstandard as zstd
-import numpy as np
 
 # Read JSON file
 with open('sample_data.json', 'r') as file:
@@ -21,7 +20,7 @@ compressors = {
 }
 
 # Define metrics dictionary
-metrics = {key: {'compression_ratio': [], 'total_compress_time': [], 'total_decompress_time': []} for key in compressors}
+metrics = {key: {} for key in compressors}
 
 # Benchmarking
 num_compress = 1000
@@ -43,13 +42,9 @@ for name, (comp_func, decomp_func) in compressors.items():
     total_decompress_time = time.time() - start_time
     
     # Record results
-    metrics[name]['compression_ratio'].append(compression_ratio)
-    metrics[name]['total_compress_time'].append(total_compress_time)
-    metrics[name]['total_decompress_time'].append(total_decompress_time)
-
-# Calculate average compression ratio
-for comp in metrics:
-    metrics[comp]['compression_ratio'] = np.mean(metrics[comp]['compression_ratio'])
+    metrics[name]['compression_ratio'] = compression_ratio
+    metrics[name]['total_compress_time'] = total_compress_time
+    metrics[name]['total_decompress_time'] = total_decompress_time
 
 # Output results
 print(json.dumps(metrics, indent=4))


### PR DESCRIPTION
This PR records the results as numbers instead of lists and removes the call to `np.mean()`.